### PR TITLE
remote: remove unnecessary mutable borrow of FetchOptions

### DIFF
--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -81,7 +81,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
     // progress.
     let mut fo = FetchOptions::new();
     fo.remote_callbacks(cb);
-    remote.download(&[] as &[&str], Some(&mut fo))?;
+    remote.download(&[] as &[&str], Some(&fo))?;
 
     {
         // If there are local objects (we got a thin pack), then tell the user

--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -57,7 +57,7 @@ fn do_fetch<'a>(
     // Perform a download and also update tips
     fo.download_tags(git2::AutotagOption::All);
     println!("Fetching {} for repo", remote.name().unwrap());
-    remote.fetch(refs, Some(&mut fo), None)?;
+    remote.fetch(refs, Some(&fo), None)?;
 
     // If there are local objects (we got a thin pack), then tell the user
     // how many objects we saved from having to cross the network.

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -233,7 +233,7 @@ impl<'repo> Remote<'repo> {
     pub fn download<Str: AsRef<str> + crate::IntoCString + Clone>(
         &mut self,
         specs: &[Str],
-        opts: Option<&mut FetchOptions<'_>>,
+        opts: Option<&FetchOptions<'_>>,
     ) -> Result<(), Error> {
         let (_a, _b, arr) = crate::util::iter2cstrs(specs.iter())?;
         let raw = opts.map(|o| o.raw());
@@ -293,7 +293,7 @@ impl<'repo> Remote<'repo> {
     pub fn fetch<Str: AsRef<str> + crate::IntoCString + Clone>(
         &mut self,
         refspecs: &[Str],
-        opts: Option<&mut FetchOptions<'_>>,
+        opts: Option<&FetchOptions<'_>>,
         reflog_msg: Option<&str>,
     ) -> Result<(), Error> {
         let (_a, _b, arr) = crate::util::iter2cstrs(refspecs.iter())?;
@@ -872,13 +872,9 @@ mod tests {
                 progress_hit.set(true);
                 true
             });
-            origin
-                .fetch(
-                    &[] as &[&str],
-                    Some(FetchOptions::new().remote_callbacks(callbacks)),
-                    None,
-                )
-                .unwrap();
+            let mut fo = FetchOptions::new();
+            fo.remote_callbacks(callbacks);
+            origin.fetch(&[] as &[&str], Some(&fo), None).unwrap();
 
             let list = t!(origin.list());
             assert_eq!(list.len(), 2);


### PR DESCRIPTION
Fetch and download seem to be requesting a mutable borrow of
FetchOptions but it is not necessary.

These appear confusing and not consistent with how FetchOptions should
be dealt with, looking for example at RepoBuilder, where it accepts an
owned value.

With this change, people will deal with a more consistent interface.